### PR TITLE
Remove failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ description = "Wrapper around the gromacs libxdrfile library. Can be used to rea
 build = "build.rs"
 
 [dependencies]
-failure = "0.1"
 lazy-init = "0.3"
 
 [dev-dependencies]

--- a/src/c_abi/mod.rs
+++ b/src/c_abi/mod.rs
@@ -1,5 +1,5 @@
+pub mod xdr_seek;
 #[allow(non_upper_case_globals)]
 pub mod xdrfile;
 pub mod xdrfile_trr;
 pub mod xdrfile_xtc;
-pub mod xdr_seek;

--- a/src/c_abi/mod.rs
+++ b/src/c_abi/mod.rs
@@ -1,5 +1,6 @@
+#![allow(non_upper_case_globals, non_camel_case_types)]
+
 pub mod xdr_seek;
-#[allow(non_upper_case_globals)]
 pub mod xdrfile;
 pub mod xdrfile_trr;
 pub mod xdrfile_xtc;

--- a/src/c_abi/xdr_seek.rs
+++ b/src/c_abi/xdr_seek.rs
@@ -103,12 +103,11 @@ extern "C" {
     pub fn xdr_flush(xd: *mut XDRFILE) -> ::std::os::raw::c_int;
 }
 
-
 #[cfg(test)]
 mod tests {
 
-    use super::*;
     use super::super::xdrfile_xtc::*;
+    use super::*;
     use std::ffi::CString;
 
     #[test]
@@ -119,8 +118,8 @@ mod tests {
         let mut step: i32 = 5;
         let box_vec = [[0.0; 3]; 3];
         let x_p = std::ptr::null_mut();
-        let mut prec: f32 = 0.0; 
-        
+        let mut prec: f32 = 0.0;
+
         unsafe {
             let mode = CString::new("r").unwrap();
             let xdr = xdrfile_open(path.as_ptr(), mode.as_ptr());
@@ -129,20 +128,25 @@ mod tests {
             let tell = xdr_tell(xdr);
             assert!(tell == 0, "{}", tell);
 
-            read_xtc(xdr, num_atoms, &mut step, &mut time,
+            read_xtc(
+                xdr,
+                num_atoms,
+                &mut step,
+                &mut time,
                 box_vec.as_ptr() as *mut Matrix,
                 x_p,
-                &mut prec);
+                &mut prec,
+            );
 
             let tell = xdr_tell(xdr);
             assert!(tell > 0, "{}", tell);
-        }   
+        }
     }
 
     #[test]
     fn test_xdr_seek() {
         let path = CString::new("tests/1l2y.xtc").unwrap();
-        
+
         unsafe {
             let mode = CString::new("r").unwrap();
             let xdr = xdrfile_open(path.as_ptr(), mode.as_ptr());
@@ -152,9 +156,9 @@ mod tests {
             assert!(tell == 0, "{}", tell);
 
             xdr_seek(xdr, 500, 0);
-            
+
             let tell = xdr_tell(xdr);
             assert!(tell == 500, "{}", tell);
-        }   
+        }
     }
 }

--- a/src/c_abi/xdrfile.rs
+++ b/src/c_abi/xdrfile.rs
@@ -1,4 +1,3 @@
-
 pub const DIM: u32 = 3;
 
 #[repr(C)]
@@ -6,7 +5,6 @@ pub const DIM: u32 = 3;
 pub struct XDRFILE {
     _unused: [u8; 0],
 }
-
 
 pub type BindgenTy1 = u32;
 pub const exdrOK: BindgenTy1 = 0;

--- a/src/c_abi/xdrfile_trr.rs
+++ b/src/c_abi/xdrfile_trr.rs
@@ -1,6 +1,5 @@
 use super::xdrfile::*;
 
-
 extern "C" {
     pub fn read_trr_natoms(
         fn_: *const ::std::os::raw::c_char,
@@ -10,7 +9,7 @@ extern "C" {
 extern "C" {
     pub fn read_trr_nframes(
         fn_: *const ::std::os::raw::c_char,
-        nframes: *const ::std::os::raw::c_ulong, 
+        nframes: *const ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -61,7 +60,7 @@ mod tests {
     #[test]
     fn test_read_trr_nframes() {
         let path = CString::new("tests/1l2y.trr").unwrap();
-        let mut nframes: u64 = 0; 
+        let mut nframes: u64 = 0;
 
         unsafe {
             let code = read_trr_nframes(path.as_ptr() as *const i8, &mut nframes);
@@ -83,19 +82,25 @@ mod tests {
 
         let box_vec: Matrix = [[1.0, 2.0, 3.0], [2.0, 1.0, 3.0], [3.0, 2.0, 1.0]];
         let x: Vec<Rvec> = vec![[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]];
-        let v: Vec<Rvec>  = vec![[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]];
+        let v: Vec<Rvec> = vec![[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]];
         let f: Vec<Rvec> = vec![[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]];
-        
+
         unsafe {
             let mode = CString::new("w").unwrap();
             let xdr = xdrfile_open(tmp_path.as_ptr(), mode.as_ptr());
-            let write_code = write_trr(xdr, natoms, step, time, lambda,
+            let write_code = write_trr(
+                xdr,
+                natoms,
+                step,
+                time,
+                lambda,
                 box_vec.as_ptr() as *mut Matrix,
                 x.as_ptr() as *mut Rvec,
                 v.as_ptr() as *mut Rvec,
-                f.as_ptr() as *mut Rvec);
+                f.as_ptr() as *mut Rvec,
+            );
             assert!(write_code as u32 == exdrOK);
-            xdrfile_close(xdr); 
+            xdrfile_close(xdr);
         }
 
         // read atoms from tempfile
@@ -111,13 +116,19 @@ mod tests {
         unsafe {
             let mode = CString::new("r").unwrap();
             let xdr = xdrfile_open(tmp_path.as_ptr(), mode.as_ptr());
-            let read_code = read_trr(xdr, natoms, &mut step2, &mut time2,
-                &mut lambda2, box_vec2.as_ptr() as *mut Matrix,
+            let read_code = read_trr(
+                xdr,
+                natoms,
+                &mut step2,
+                &mut time2,
+                &mut lambda2,
+                box_vec2.as_ptr() as *mut Matrix,
                 x2.as_ptr() as *mut Rvec,
                 v2.as_ptr() as *mut Rvec,
-                f2.as_ptr() as *mut Rvec);
+                f2.as_ptr() as *mut Rvec,
+            );
             assert!(read_code as u32 == exdrOK);
-            xdrfile_close(xdr); 
+            xdrfile_close(xdr);
         }
 
         // make sure everything is still the same
@@ -129,5 +140,4 @@ mod tests {
         assert!(v2 == v);
         assert!(f2 == f);
     }
-
 }

--- a/src/c_abi/xdrfile_xtc.rs
+++ b/src/c_abi/xdrfile_xtc.rs
@@ -1,6 +1,5 @@
 use super::xdrfile::*;
 
-
 extern "C" {
     pub fn read_xtc_natoms(
         fn_: *const ::std::os::raw::c_char,
@@ -10,7 +9,7 @@ extern "C" {
 extern "C" {
     pub fn read_xtc_nframes(
         fn_: *const ::std::os::raw::c_char,
-        nframes: *const ::std::os::raw::c_ulong, 
+        nframes: *const ::std::os::raw::c_ulong,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -57,7 +56,7 @@ mod tests {
     #[test]
     fn test_read_xtc_nframes() {
         let path = CString::new("tests/1l2y.xtc").unwrap();
-        let mut nframes: u64 = 0; 
+        let mut nframes: u64 = 0;
 
         unsafe {
             let code = read_xtc_nframes(path.as_ptr() as *const i8, &mut nframes);
@@ -77,15 +76,21 @@ mod tests {
         let step: i32 = 5;
         let box_vec: Matrix = [[1.0, 2.0, 3.0], [2.0, 1.0, 3.0], [3.0, 2.0, 1.0]];
         let x: Vec<Rvec> = vec![[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]];
-        
+
         unsafe {
             let mode = CString::new("w").unwrap();
             let xdr = xdrfile_open(tmp_path.as_ptr(), mode.as_ptr());
-            let write_code = write_xtc(xdr, natoms, step, time,
-                box_vec.as_ptr() as *mut Matrix, x.as_ptr() as *mut Rvec,
-                1000.0);
+            let write_code = write_xtc(
+                xdr,
+                natoms,
+                step,
+                time,
+                box_vec.as_ptr() as *mut Matrix,
+                x.as_ptr() as *mut Rvec,
+                1000.0,
+            );
             assert!(write_code as u32 == exdrOK);
-            xdrfile_close(xdr); 
+            xdrfile_close(xdr);
         }
 
         // read atoms from tempfile
@@ -98,11 +103,17 @@ mod tests {
         unsafe {
             let mode = CString::new("r").unwrap();
             let xdr = xdrfile_open(tmp_path.as_ptr(), mode.as_ptr());
-            let read_code = read_xtc(xdr, natoms, &mut step2, &mut time2,
-                box_vec2.as_ptr() as *mut Matrix, x2.as_ptr() as *mut Rvec,
-                &mut prec);
+            let read_code = read_xtc(
+                xdr,
+                natoms,
+                &mut step2,
+                &mut time2,
+                box_vec2.as_ptr() as *mut Matrix,
+                x2.as_ptr() as *mut Rvec,
+                &mut prec,
+            );
             assert!(read_code as u32 == exdrOK);
-            xdrfile_close(xdr); 
+            xdrfile_close(xdr);
         }
 
         // make sure everything is still the same

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -12,37 +12,42 @@ pub struct Frame {
     /// Time step (usually in picoseconds)
     pub time: f32,
 
-    /// 3x3 box vector 
+    /// 3x3 box vector
     pub box_vector: [[f32; 3usize]; 3usize],
-    
-    /// 3D coordinates for N atoms where N is num_atoms 
+
+    /// 3D coordinates for N atoms where N is num_atoms
     pub coords: Vec<[f32; 3usize]>,
 }
 
 impl Default for Frame {
     fn default() -> Frame {
-        Frame { 
+        Frame {
             num_atoms: 0,
             step: 0,
             time: 0.0,
             box_vector: [[0.0; 3]; 3],
-            coords: Vec::with_capacity(0)
+            coords: Vec::with_capacity(0),
         }
     }
 }
 
 impl fmt::Debug for Frame {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Frame {{ atoms: {}, step: {}, time: {}, \
-            box: {:?}, coords: {:?} }}", self.num_atoms, self.step, self.time,
-            self.box_vector, self.coords)
+        write!(
+            f,
+            "Frame {{ atoms: {}, step: {}, time: {}, \
+            box: {:?}, coords: {:?} }}",
+            self.num_atoms, self.step, self.time, self.box_vector, self.coords
+        )
     }
 }
 
 impl Frame {
     /// Creates an empty frame with a capacity of 0
     pub fn new() -> Frame {
-        Frame{ ..Default::default() }
+        Frame {
+            ..Default::default()
+        }
     }
 
     /// Creates a frame with the given capacity
@@ -52,27 +57,26 @@ impl Frame {
             coords: vec![[0.0, 0.0, 0.0]; num_atoms as usize],
             ..Default::default()
         }
-
     }
 
-    /// Filters the frame by removing all atoms not matching the given indeces. 
+    /// Filters the frame by removing all atoms not matching the given indeces.
     pub fn filter_coords(self: &mut Frame, indeces: &[usize]) {
-        self.coords = self.coords.iter() 
+        self.coords = self
+            .coords
+            .iter()
             .map(|elem| elem.clone())
             .enumerate()
             .filter(|&(i, _)| indeces.contains(&i))
             .map(|(_, elem)| elem)
             .collect();
         self.num_atoms = self.coords.len() as u32;
-    }   
+    }
 
     /// Length of the frame (number of atoms)
     pub fn len(self: &Frame) -> usize {
         self.num_atoms as usize
-    } 
+    }
 }
-
-
 
 #[cfg(test)]
 mod tests {
@@ -91,12 +95,12 @@ mod tests {
         frame.coords[0] = [1.0, 2.0, 3.0];
         frame.coords[1] = [4.0, 5.0, 6.0];
         frame.coords[2] = [7.0, 8.0, 9.0];
-        let filter: Vec<usize> = vec![1,2];
+        let filter: Vec<usize> = vec![1, 2];
         let mut frame_new = frame.clone();
         frame_new.filter_coords(&filter);
         assert!(frame_new.num_atoms as usize == filter.len());
         assert!(frame_new.coords[0] == frame.coords[1]);
-        assert!(frame_new.coords[1] == frame.coords[2]);           
+        assert!(frame_new.coords[1] == frame.coords[2]);
     }
 
     #[test]

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -53,7 +53,7 @@ impl Frame {
     /// Creates a frame with the given capacity
     pub fn with_capacity(num_atoms: u32) -> Frame {
         Frame {
-            num_atoms: num_atoms,
+            num_atoms,
             coords: vec![[0.0, 0.0, 0.0]; num_atoms as usize],
             ..Default::default()
         }

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::c_abi::xdrfile::exdrENDOFFILE;
+use crate::*;
 use failure::Error;
 use std::rc::Rc;
 
@@ -13,14 +13,14 @@ impl IntoIterator for XTCTrajectory {
         XTCTrajectoryIterator {
             trajectory: self,
             item: Rc::new(Frame::with_capacity(num_atoms)),
-            has_error: false
+            has_error: false,
         }
     }
 }
 
-/* 
+/*
 Iterator for trajectories. This iterator yields a Result<Frame, Error>
-for each frame in the trajectory file and stops with yielding None once the 
+for each frame in the trajectory file and stops with yielding None once the
 trajectory is finished. Also yields None after the first occurence of an error
 */
 pub struct XTCTrajectoryIterator {
@@ -32,18 +32,19 @@ pub struct XTCTrajectoryIterator {
 impl Iterator for XTCTrajectoryIterator {
     type Item = Result<Rc<Frame>, Error>;
 
-    fn next(&mut self) -> Option<Self::Item> { // Reuse old frame
+    fn next(&mut self) -> Option<Self::Item> {
+        // Reuse old frame
         if self.has_error {
             return None;
         }
 
         let item: &mut Frame = match Rc::get_mut(&mut self.item) {
             Some(item) => item,
-            None => {  // caller kept frame. Create new one
+            None => {
+                // caller kept frame. Create new one
                 self.item = Rc::new(Frame::with_capacity(self.item.num_atoms));
                 Rc::get_mut(&mut self.item).unwrap()
             }
-
         };
         match self.trajectory.read(item) {
             Ok(()) => Some(Ok(Rc::clone(&self.item))),
@@ -55,7 +56,7 @@ impl Iterator for XTCTrajectoryIterator {
                     Some(Err(msg))
                 }
             }
-        } 
+        }
     }
 }
 
@@ -69,14 +70,14 @@ impl IntoIterator for TRRTrajectory {
         TRRTrajectoryIterator {
             trajectory: self,
             item: Rc::new(Frame::with_capacity(num_atoms)),
-            has_error: false
+            has_error: false,
         }
     }
 }
 
-/* 
+/*
 Iterator for trajectories. This iterator yields a Result<Frame, Error>
-for each frame in the trajectory file and stops with yielding None once the 
+for each frame in the trajectory file and stops with yielding None once the
 trajectory is finished. Also yields None after the first occurence of an error
 */
 pub struct TRRTrajectoryIterator {
@@ -88,18 +89,19 @@ pub struct TRRTrajectoryIterator {
 impl Iterator for TRRTrajectoryIterator {
     type Item = Result<Rc<Frame>, Error>;
 
-    fn next(&mut self) -> Option<Self::Item> { // Reuse old frame
+    fn next(&mut self) -> Option<Self::Item> {
+        // Reuse old frame
         if self.has_error {
             return None;
         }
 
         let item: &mut Frame = match Rc::get_mut(&mut self.item) {
             Some(item) => item,
-            None => {  // caller kept frame. Create new one
+            None => {
+                // caller kept frame. Create new one
                 self.item = Rc::new(Frame::with_capacity(self.item.num_atoms));
                 Rc::get_mut(&mut self.item).unwrap()
             }
-
         };
         match self.trajectory.read(item) {
             Ok(()) => Some(Ok(Rc::clone(&self.item))),
@@ -111,7 +113,7 @@ impl Iterator for TRRTrajectoryIterator {
                     Some(Err(msg))
                 }
             }
-        } 
+        }
     }
 }
 

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,10 +1,9 @@
 use crate::c_abi::xdrfile::exdrENDOFFILE;
 use crate::*;
-use failure::Error;
 use std::rc::Rc;
 
 impl IntoIterator for XTCTrajectory {
-    type Item = Result<Rc<Frame>, Error>;
+    type Item = Result<Rc<Frame>>;
     type IntoIter = XTCTrajectoryIterator;
 
     fn into_iter(mut self) -> Self::IntoIter {
@@ -30,7 +29,7 @@ pub struct XTCTrajectoryIterator {
 }
 
 impl Iterator for XTCTrajectoryIterator {
-    type Item = Result<Rc<Frame>, Error>;
+    type Item = Result<Rc<Frame>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Reuse old frame
@@ -61,7 +60,7 @@ impl Iterator for XTCTrajectoryIterator {
 }
 
 impl IntoIterator for TRRTrajectory {
-    type Item = Result<Rc<Frame>, Error>;
+    type Item = Result<Rc<Frame>>;
     type IntoIter = TRRTrajectoryIterator;
 
     fn into_iter(mut self) -> Self::IntoIter {
@@ -87,7 +86,7 @@ pub struct TRRTrajectoryIterator {
 }
 
 impl Iterator for TRRTrajectoryIterator {
-    type Item = Result<Rc<Frame>, Error>;
+    type Item = Result<Rc<Frame>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // Reuse old frame

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //!        assert_eq!(first_atom_coords, [-0.8901, 0.4127, -0.055499997]);
 //!    }
 //!    Err(msg) => {
-//!        panic!("Something went wrong: {}", msg);    
+//!        panic!("Something went wrong: {}", msg);
 //!    }
 //! }
 //! ```
@@ -104,6 +104,7 @@ fn path_to_cstring(path: &Path) -> CString {
 /// A safe wrapper around the c implementation of an XDRFile
 struct XDRFile {
     xdrfile: *mut XDRFILE,
+    #[allow(dead_code)]
     filemode: FileMode,
     path: String,
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod integration {
 
+    use std::path::Path;
     use std::rc::Rc;
     use xdrfile::*;
-    use std::path::Path;
 
     #[test]
     fn test_use_library() {
@@ -25,8 +25,7 @@ mod integration {
         let trj = XTCTrajectory::open(path, FileMode::Read).unwrap();
         let frames: Vec<Rc<Frame>> = trj.into_iter().filter_map(Result::ok).collect();
         for (idx, frame) in frames.iter().enumerate() {
-            assert_eq!(frame.step as usize, idx+1);
+            assert_eq!(frame.step as usize, idx + 1);
         }
     }
-
 }


### PR DESCRIPTION
The `failure` library previously used for errors by `xdrfile` has been deprecated in favour of updates to the `std::error::Error` trait. This PR replaces all use of that library with a new error type based on the updated trait API. It adds no dependencies as the trait is implemented by hand rather than, say, with the `thiserror` crate.

I've also run the library through rustfmt and suppressed or corrected warnings and hints that are produced by rustc. These changes are in separate commits in case you'd like to leave them aside.

Thanks for your work on this library! I have plans for more PRs :)