### PR TITLE
Rusty error codes

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,220 @@
+use crate::c_abi;
+use crate::FileMode;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ErrorTask {
+    OpenFile(PathBuf, FileMode),
+    ReadNumAtoms,
+    Read,
+    Write,
+    Flush,
+    ToCString(Option<std::ffi::NulError>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Error {
+    code: Option<ErrorCode>,
+    task: ErrorTask,
+}
+
+impl Error {
+    pub fn task(&self) -> &ErrorTask {
+        &self.task
+    }
+
+    pub fn code(&self) -> &Option<ErrorCode> {
+        &self.code
+    }
+
+    pub fn is_eof(&self) -> bool {
+        self.code.as_ref().map_or(false, ErrorCode::is_eof)
+    }
+
+    pub fn from_convert() -> Self {
+        Self {
+            code: None,
+            task: ErrorTask::ToCString(None),
+        }
+    }
+
+    pub fn from_open(path: impl AsRef<Path>, mode: FileMode) -> Self {
+        Self {
+            code: None,
+            task: ErrorTask::OpenFile(path.as_ref().into(), mode),
+        }
+    }
+
+    pub fn from_read_num_atoms(code: impl Into<ErrorCode>) -> Self {
+        Self {
+            code: Some(code.into()),
+            task: ErrorTask::ReadNumAtoms,
+        }
+    }
+
+    pub fn from_read(code: impl Into<ErrorCode>) -> Self {
+        Self {
+            code: Some(code.into()),
+            task: ErrorTask::Read,
+        }
+    }
+
+    pub fn from_write(code: impl Into<ErrorCode>) -> Self {
+        Self {
+            code: Some(code.into()),
+            task: ErrorTask::Write,
+        }
+    }
+
+    pub fn from_flush(code: impl Into<ErrorCode>) -> Self {
+        Self {
+            code: Some(code.into()),
+            task: ErrorTask::Flush,
+        }
+    }
+}
+
+impl From<std::ffi::NulError> for Error {
+    fn from(err: std::ffi::NulError) -> Self {
+        Self {
+            code: None,
+            task: ErrorTask::ToCString(Some(err)),
+        }
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use ErrorTask::*;
+        match &self.task {
+            OpenFile(path, mode) => write!(
+                f,
+                "Failed to open file at {path:?} with mode {mode:?}",
+                path = path,
+                mode = mode
+            ),
+            ReadNumAtoms => write!(
+                f,
+                "Failed to read atom number from trajectory: C API returned error code {:?}",
+                self.code
+            ),
+            Read => write!(
+                f,
+                "Failed to read trajectory: C API returned error code {:?}",
+                self.code
+            ),
+            Write => write!(
+                f,
+                "Failed to write trajectory: C API returned error code {:?}",
+                self.code
+            ),
+            Flush => write!(
+                f,
+                "Failed to flush trajectory: C API returned error code {:?}",
+                self.code
+            ),
+            ToCString(_) => write!(
+                f,
+                "Path cannot be converted to a C string because it has a null byte"
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ErrorCode {
+    ExdrOk,
+    ExdrHeader,
+    ExdrString,
+    ExdrDouble,
+    ExdrInt,
+    ExdrFloat,
+    ExdrUint,
+    Exdr3dx,
+    ExdrClose,
+    ExdrMagic,
+    ExdrNoMem,
+    ExdrEndOfFile,
+    ExdrFileNotFound,
+    ExdrNr,
+    UnmatchedCode(c_abi::xdrfile::BindgenTy1),
+}
+
+impl ErrorCode {
+    pub fn is_eof(&self) -> bool {
+        match self {
+            Self::ExdrEndOfFile => true,
+            _ => false,
+        }
+    }
+}
+
+impl From<c_abi::xdrfile::BindgenTy1> for ErrorCode {
+    fn from(code: c_abi::xdrfile::BindgenTy1) -> Self {
+        match code {
+            c_abi::xdrfile::exdrOK => Self::ExdrOk,
+            c_abi::xdrfile::exdrHEADER => Self::ExdrHeader,
+            c_abi::xdrfile::exdrSTRING => Self::ExdrString,
+            c_abi::xdrfile::exdrDOUBLE => Self::ExdrDouble,
+            c_abi::xdrfile::exdrINT => Self::ExdrInt,
+            c_abi::xdrfile::exdrFLOAT => Self::ExdrFloat,
+            c_abi::xdrfile::exdrUINT => Self::ExdrUint,
+            c_abi::xdrfile::exdr3DX => Self::Exdr3dx,
+            c_abi::xdrfile::exdrCLOSE => Self::ExdrClose,
+            c_abi::xdrfile::exdrMAGIC => Self::ExdrMagic,
+            c_abi::xdrfile::exdrNOMEM => Self::ExdrNoMem,
+            c_abi::xdrfile::exdrENDOFFILE => Self::ExdrEndOfFile,
+            c_abi::xdrfile::exdrFILENOTFOUND => Self::ExdrFileNotFound,
+            c_abi::xdrfile::exdrNR => Self::ExdrNr,
+            code => Self::UnmatchedCode(code),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_eof() {
+        let error = Error {
+            code: Some(c_abi::xdrfile::exdrENDOFFILE.into()),
+            task: ErrorTask::Read,
+        };
+        assert!(error.is_eof());
+
+        let error = Error {
+            code: Some(ErrorCode::ExdrEndOfFile),
+            task: ErrorTask::Read,
+        };
+        assert!(error.is_eof());
+
+        let error = Error {
+            code: Some((c_abi::xdrfile::exdrENDOFFILE + 1).into()),
+            task: ErrorTask::Read,
+        };
+        assert!(!error.is_eof());
+
+        let error = Error {
+            code: Some(0.into()),
+            task: ErrorTask::Write,
+        };
+        assert!(!error.is_eof());
+
+        let error = Error {
+            code: Some(255.into()),
+            task: ErrorTask::Flush,
+        };
+        assert!(!error.is_eof());
+
+        let error = Error {
+            code: None,
+            task: ErrorTask::OpenFile(PathBuf::from("not/a/file"), FileMode::Read),
+        };
+        assert!(!error.is_eof());
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -43,8 +43,11 @@ impl Error {
 
     /// Get the task being attempted when the C API returned an error, if any
     pub fn task(&self) -> Option<ErrorTask> {
+        use std::error::Error as _;
         if let Error::CApiError { task, .. } = self {
             Some(*task)
+        } else if let Some(e) = self.source() {
+            e.downcast_ref::<Self>().and_then(Self::task)
         } else {
             None
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -115,7 +115,7 @@ impl std::error::Error for Error {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy)]
 pub enum ErrorCode {
     ExdrOk,
     ExdrHeader,
@@ -139,6 +139,15 @@ impl ErrorCode {
         match self {
             Self::ExdrEndOfFile => true,
             _ => false,
+        }
+    }
+
+    pub fn check<T>(code: impl Into<Self>, value: T) -> std::result::Result<T, Self> {
+        let code = code.into();
+        if let Self::ExdrOk = code {
+            Ok(value)
+        } else {
+            Err(code)
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -96,9 +96,9 @@ pub enum ErrorKind {
     WrongSizeFrame { expected: usize, found: usize },
     /// C API failed to open a file (No return code provided)
     CouldNotOpen { path: PathBuf, mode: FileMode },
-    /// &str could not be converted to &OsStr, probably because it is invalid unicode
+    /// A path could not be converted to &OsStr, probably because it is invalid unicode
     InvalidOsStr,
-    /// &OsStr could not be converted to &CStr because it had a null byte
+    /// A path could not be converted to &CStr because it had a null byte
     NullInStr(std::ffi::NulError),
 }
 
@@ -146,8 +146,8 @@ impl std::fmt::Display for ErrorKind {
             CouldNotOpen { path, mode } => {
                 write!(f, "Could not open file at {:?} in mode {:?}", path, mode)
             }
-            InvalidOsStr => write!(f, "CStr must be valid unicode on this platform"),
-            NullInStr(_err) => write!(f, "CStr cannot include null bytes"),
+            InvalidOsStr => write!(f, "Paths must be valid unicode on this platform"),
+            NullInStr(_err) => write!(f, "Paths cannot include null bytes"),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,8 +26,7 @@ pub enum Error {
     InvalidOsStr,
     /// A path could not be converted to &CStr because it had a null byte
     NullInStr(std::ffi::NulError),
-    CheckNAtomsDuringRead(Box<Error>),
-    CheckNAtomsDuringIter(Box<Error>),
+    CouldNotCheckNAtoms(Box<Error>),
 }
 
 impl Error {
@@ -64,7 +63,7 @@ impl std::error::Error for Error {
         use Error::*;
         match &self {
             NullInStr(err) => Some(err),
-            CheckNAtomsDuringRead(err) | CheckNAtomsDuringIter(err) => Some(err.as_ref()),
+            CouldNotCheckNAtoms(err) => Some(err.as_ref()),
             _ => None,
         }
     }
@@ -123,14 +122,10 @@ impl std::fmt::Display for Error {
             }
             InvalidOsStr => write!(f, "Paths must be valid unicode on this platform"),
             NullInStr(_err) => write!(f, "Paths cannot include null bytes"),
-            CheckNAtomsDuringRead(_err) => write!(
+            CouldNotCheckNAtoms(_err) => write!(
                 f,
-                "Failed to check number of atoms in trajectory while reading a frame"
-            ),
-            CheckNAtomsDuringIter(_err) => write!(
-                f,
-                "Failed to check number of atoms in trajectory while creating iterator"
-            ),
+                "Failed to read number of atoms in trajectory file"
+            )
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -31,42 +31,42 @@ impl Error {
         self.code.as_ref().map_or(false, ErrorCode::is_eof)
     }
 
-    pub fn from_convert() -> Self {
+    pub(crate) fn from_convert() -> Self {
         Self {
             code: None,
             task: ErrorTask::ToCString(None),
         }
     }
 
-    pub fn from_open(path: impl AsRef<Path>, mode: FileMode) -> Self {
+    pub(crate) fn from_open(path: impl AsRef<Path>, mode: FileMode) -> Self {
         Self {
             code: None,
             task: ErrorTask::OpenFile(path.as_ref().into(), mode),
         }
     }
 
-    pub fn from_read_num_atoms(code: impl Into<ErrorCode>) -> Self {
+    pub(crate) fn from_read_num_atoms(code: impl Into<ErrorCode>) -> Self {
         Self {
             code: Some(code.into()),
             task: ErrorTask::ReadNumAtoms,
         }
     }
 
-    pub fn from_read(code: impl Into<ErrorCode>) -> Self {
+    pub(crate) fn from_read(code: impl Into<ErrorCode>) -> Self {
         Self {
             code: Some(code.into()),
             task: ErrorTask::Read,
         }
     }
 
-    pub fn from_write(code: impl Into<ErrorCode>) -> Self {
+    pub(crate) fn from_write(code: impl Into<ErrorCode>) -> Self {
         Self {
             code: Some(code.into()),
             task: ErrorTask::Write,
         }
     }
 
-    pub fn from_flush(code: impl Into<ErrorCode>) -> Self {
+    pub(crate) fn from_flush(code: impl Into<ErrorCode>) -> Self {
         Self {
             code: Some(code.into()),
             task: ErrorTask::Flush,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -114,7 +114,11 @@ impl std::fmt::Display for Error {
             Read => write!(f, "Failed to read trajectory"),
             Write => write!(f, "Failed to write trajectory"),
             Flush => write!(f, "Failed to flush trajectory"),
-            ToCString(_) => write!(
+            ToCString(None) => write!(
+                f,
+                "Path cannot be converted to a C string because it was invalid Unicode"
+            ),
+            ToCString(Some(_)) => write!(
                 f,
                 "Path cannot be converted to a C string because it has a null byte"
             ),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -58,21 +58,6 @@ impl Error {
     pub fn is_eof(&self) -> bool {
         self.code().map_or(false, |e| e.is_eof())
     }
-
-    /// Convert an error code and output value from a C call to a Result
-    ///
-    /// `code` should be an integer return code returned from the C API. `value` should be the
-    /// function's output, which is generally either `()` or one of its arguments. If `code`
-    /// indicates the function returned successfully, the value is returned; otherwise, the
-    /// code is converted into the appropriate `Error`.
-    pub fn check_code<T>(code: impl Into<ErrorCode>, value: T, task: ErrorTask) -> Result<T, Self> {
-        let code: ErrorCode = code.into();
-        if let ErrorCode::ExdrOk = code {
-            Ok(value)
-        } else {
-            Err(Self::CApiError { code, task })
-        }
-    }
 }
 
 impl std::error::Error for Error {
@@ -82,6 +67,13 @@ impl std::error::Error for Error {
             Error::CouldNotCheckNAtoms(err) => Some(err.as_ref()),
             _ => None,
         }
+    }
+}
+
+impl From<(ErrorCode, ErrorTask)> for Error {
+    fn from(value: (ErrorCode, ErrorTask)) -> Self {
+        let (code, task) = value;
+        Self::CApiError { code, task }
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -126,6 +126,8 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         if let Some(e) = &self.code {
             Some(e)
+        } else if let ErrorTask::ToCString(Some(e)) = &self.task {
+            Some(e)
         } else {
             None
         }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// A frame represents a single step in a trajectory.
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 pub struct Frame {
     /// Number of atoms in the frame
     pub num_atoms: u32,
@@ -13,10 +13,10 @@ pub struct Frame {
     pub time: f32,
 
     /// 3x3 box vector
-    pub box_vector: [[f32; 3]; 3],
+    pub box_vector: [[f32; 3usize]; 3usize],
 
     /// 3D coordinates for N atoms where N is num_atoms
-    pub coords: Vec<[f32; 3]>,
+    pub coords: Vec<[f32; 3usize]>,
 }
 
 impl Default for Frame {
@@ -75,12 +75,6 @@ impl Frame {
     /// Length of the frame (number of atoms)
     pub fn len(self: &Frame) -> usize {
         self.num_atoms as usize
-    }
-
-    /// Resizes the Frame in-place so that num_atoms is equal to new_size.
-    pub fn resize(&mut self, new_size: u32) {
-        self.num_atoms = new_size;
-        self.coords.resize(new_size as usize, [0.0; 3]);
     }
 }
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// A frame represents a single step in a trajectory.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct Frame {
     /// Number of atoms in the frame
     pub num_atoms: u32,
@@ -13,10 +13,10 @@ pub struct Frame {
     pub time: f32,
 
     /// 3x3 box vector
-    pub box_vector: [[f32; 3usize]; 3usize],
+    pub box_vector: [[f32; 3]; 3],
 
     /// 3D coordinates for N atoms where N is num_atoms
-    pub coords: Vec<[f32; 3usize]>,
+    pub coords: Vec<[f32; 3]>,
 }
 
 impl Default for Frame {
@@ -75,6 +75,12 @@ impl Frame {
     /// Length of the frame (number of atoms)
     pub fn len(self: &Frame) -> usize {
         self.num_atoms as usize
+    }
+
+    /// Resizes the Frame in-place so that num_atoms is equal to new_size.
+    pub fn resize(&mut self, new_size: u32) {
+        self.num_atoms = new_size;
+        self.coords.resize(new_size as usize, [0.0; 3]);
     }
 }
 

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -11,7 +11,6 @@ fn into_iter_inner<T: Trajectory>(mut traj: T) -> TrajectoryIterator<T> {
         trajectory: traj,
         item: Rc::new(frame),
         has_error: false,
-        num_atoms,
     }
 }
 
@@ -42,14 +41,14 @@ pub struct TrajectoryIterator<T> {
     trajectory: T,
     item: Rc<Frame>,
     has_error: bool,
-    num_atoms: Result<u32>,
 }
 
 impl<T: Trajectory> TrajectoryIterator<T> {
     /// Inner function for `next()`  to seperate error handling from iteration logic
     fn next_inner(&mut self) -> <Self as Iterator>::Item {
         // If we couldn't read the number of frames when we called into_iter, return that error now
-        let num_atoms = match &self.num_atoms {
+        // It's OK to do this every frame because the result is cached by Trajectory
+        let num_atoms = match &self.trajectory.get_num_atoms() {
             &Ok(n) => n,
             Err(e) => Err(Error::CheckNAtomsDuringIter(Box::new(e.clone())))?,
         };

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -50,7 +50,7 @@ impl<T: Trajectory> TrajectoryIterator<T> {
         // It's OK to do this every frame because the result is cached by Trajectory
         let num_atoms = match &self.trajectory.get_num_atoms() {
             &Ok(n) => n,
-            Err(e) => Err(Error::CheckNAtomsDuringIter(Box::new(e.clone())))?,
+            Err(e) => Err(Error::CouldNotCheckNAtoms(Box::new(e.clone())))?,
         };
 
         // Reuse old frame

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -662,4 +662,15 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_check_code() {
+        let code: ErrorCode = 0.into();
+        assert!(!check_code(code, ErrorTask::Read).is_some());
+
+        for i in vec![1, 10, 100, 1000] {
+            let code: ErrorCode = i.into();
+            assert!(check_code(code, ErrorTask::Read).is_some());
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ impl FileMode {
 
 fn path_to_cstring(path: impl AsRef<Path>) -> Result<CString> {
     let s = path.as_ref().to_str().ok_or(Error::InvalidOsStr)?;
-    CString::new(s).map_err(Error::from)
+    Ok(CString::new(s)?)
 }
 
 /// Convert an error code from a C call to an Error
@@ -118,7 +118,6 @@ pub fn check_code(code: impl Into<ErrorCode>, task: ErrorTask) -> Option<Error> 
         Some(Error::from((code, task)))
     }
 }
-
 
 /// A safe wrapper around the c implementation of an XDRFile
 struct XDRFile {
@@ -150,7 +149,7 @@ impl XDRFile {
                 })
             } else {
                 // Something went wrong. But the C api does not tell us what
-                Err(Error::from((path, filemode)))
+                Err((path, filemode))?
             }
         }
     }
@@ -221,7 +220,7 @@ impl Trajectory for XTCTrajectory {
             .get_num_atoms()
             .map_err(|e| Error::CouldNotCheckNAtoms(Box::new(e)))? as usize;
         if num_atoms != frame.coords.len() {
-            return Err(Error::from((&*frame, num_atoms)));
+            Err((&*frame, num_atoms))?;
         }
 
         unsafe {
@@ -340,7 +339,7 @@ impl Trajectory for TRRTrajectory {
             .get_num_atoms()
             .map_err(|e| Error::CouldNotCheckNAtoms(Box::new(e)))? as usize;
         if num_atoms != frame.coords.len() {
-            return Err(Error::from((&*frame, num_atoms)));
+            Err((&*frame, num_atoms))?;
         }
 
         unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,9 @@ impl Trajectory for XTCTrajectory {
     fn read(&mut self, frame: &mut Frame) -> Result<()> {
         let mut step: i32 = 0;
 
-        let num_atoms = self.get_num_atoms()? as usize;
+        let num_atoms = self
+            .get_num_atoms()
+            .map_err(|e| Error::CouldNotCheckNAtoms(Box::new(e)))? as usize;
         if num_atoms != frame.coords.len() {
             return Err(Error::from((&*frame, num_atoms)));
         }
@@ -303,7 +305,9 @@ impl Trajectory for TRRTrajectory {
         let mut step: i32 = 0;
         let mut lambda: f32 = 0.0;
 
-        let num_atoms = self.get_num_atoms()? as usize;
+        let num_atoms = self
+            .get_num_atoms()
+            .map_err(|e| Error::CouldNotCheckNAtoms(Box::new(e)))? as usize;
         if num_atoms != frame.coords.len() {
             return Err(Error::from((&*frame, num_atoms)));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,9 +216,9 @@ impl Trajectory for XTCTrajectory {
     fn read(&mut self, frame: &mut Frame) -> Result<()> {
         let mut step: i32 = 0;
 
-        let num_atoms = self
-            .get_num_atoms()
-            .map_err(|e| Error::CouldNotCheckNAtoms(Box::new(e)))? as usize;
+        let num_atoms =
+            self.get_num_atoms()
+                .map_err(|e| Error::CheckNAtomsDuringRead(Box::new(e)))? as usize;
         if num_atoms != frame.coords.len() {
             Err((&*frame, num_atoms))?;
         }
@@ -335,9 +335,9 @@ impl Trajectory for TRRTrajectory {
         let mut step: i32 = 0;
         let mut lambda: f32 = 0.0;
 
-        let num_atoms = self
-            .get_num_atoms()
-            .map_err(|e| Error::CouldNotCheckNAtoms(Box::new(e)))? as usize;
+        let num_atoms =
+            self.get_num_atoms()
+                .map_err(|e| Error::CheckNAtomsDuringRead(Box::new(e)))? as usize;
         if num_atoms != frame.coords.len() {
             Err((&*frame, num_atoms))?;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,11 +206,9 @@ impl Trajectory for XTCTrajectory {
     fn read(&mut self, frame: &mut Frame) -> Result<()> {
         let mut step: i32 = 0;
 
-        let num_atoms = self
-            .get_num_atoms()
-            .map_err(|e| e.with_task(ErrorTask::Read))? as usize;
+        let num_atoms = self.get_num_atoms()? as usize;
         if num_atoms != frame.coords.len() {
-            return Err(Error::from((&*frame, num_atoms)).with_task(ErrorTask::Read));
+            return Err(Error::from((&*frame, num_atoms)));
         }
 
         unsafe {
@@ -309,11 +307,9 @@ impl Trajectory for TRRTrajectory {
         let mut step: i32 = 0;
         let mut lambda: f32 = 0.0;
 
-        let num_atoms = self
-            .get_num_atoms()
-            .map_err(|e| e.with_task(ErrorTask::Read))? as usize;
+        let num_atoms = self.get_num_atoms()? as usize;
         if num_atoms != frame.coords.len() {
-            return Err(Error::from((&*frame, num_atoms)).with_task(ErrorTask::Read));
+            return Err(Error::from((&*frame, num_atoms)));
         }
 
         unsafe {
@@ -504,7 +500,6 @@ mod tests {
 
         let result = xtc_traj.read(&mut frame);
         if let Err(e) = result {
-            assert_eq!(e.task(), &Some(ErrorTask::Read));
             assert!(if let ErrorKind::WrongSizeFrame { .. } = e.kind() {
                 true
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,7 @@ impl Trajectory for XTCTrajectory {
 
         let num_atoms =
             self.get_num_atoms()
-                .map_err(|e| Error::CheckNAtomsDuringRead(Box::new(e)))? as usize;
+                .map_err(|e| Error::CouldNotCheckNAtoms(Box::new(e)))? as usize;
         if num_atoms != frame.coords.len() {
             Err((&*frame, num_atoms))?;
         }
@@ -337,7 +337,7 @@ impl Trajectory for TRRTrajectory {
 
         let num_atoms =
             self.get_num_atoms()
-                .map_err(|e| Error::CheckNAtomsDuringRead(Box::new(e)))? as usize;
+                .map_err(|e| Error::CouldNotCheckNAtoms(Box::new(e)))? as usize;
         if num_atoms != frame.coords.len() {
             Err((&*frame, num_atoms))?;
         }


### PR DESCRIPTION
This PR is a bit more involved. It refactors the errors in a number of ways that are a bit more involved than the previous PR. Changes are built around a new enum `ErrorCodes` that replicates the XDR error codes. This means that users of the library will never have to directly check an integer exposed by the C API, and it streamlines error processing within the crate as well. In addition, it paves the way for more granular and useful messages to the user. Errors are checked and a Result enum constructed in a single `ErrorCodes::check()` method, and then context is added with `Result::map()`. This means that several match statements can be replaced by a single line. The `Error` type is now a struct, similar to `std::io::Error`, which includes both the context of the error as well as the error code. The error code is provided through the `Error.source()` method, meaning that it plays nicely with the popular anyhow crate for pretty application error messages.

This is a bit more of a wild one and I'll totally understand if you don't like it :) I think the `ErrorCodes` enum is a dramatic improvement, and the other changes are mostly there to support it and improve the user experience when creating applications. The alternative design I considered was to refactor out the context/task that was being done when the error occurred, as the user has access to that themselves. So then `ErrorCodes` would be the only error type. But the dual error type approach might allow for better errors in the future.

I may also be overthinking things.