### PR TITLE
XDR seek

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -139,8 +139,10 @@ pub enum ErrorTask {
     Read,
     /// A frame was being written to a file
     Write,
-    /// An file was being flushed to disk
+    /// A file was being flushed to disk
     Flush,
+    /// A seek operation was being run on a file
+    Seek,
 }
 
 impl std::fmt::Display for ErrorTask {
@@ -151,6 +153,7 @@ impl std::fmt::Display for ErrorTask {
             Read => write!(f, "reading trajectory"),
             Write => write!(f, "writing trajectory"),
             Flush => write!(f, "flushing trajectory"),
+            Seek => write!(f, "seeking in trajectory"),
         }
     }
 }


### PR DESCRIPTION
Implemented the `std::io::Seek` trait for XDRFile, and then for XTCTrajectory and TRRTrajectory. I'm not sure how useful this is but it seemed worthwhile; the C methods are right there after all. I had some ideas for a borrowing iterator using seek but they didn't really pan out so they're not included. A unit test is included for both the `tell` and `seek` methods. The `io::Error` required by the seek trait wraps one of our own errors, so there should be nice error messages. 

I've already rebased this to #3, which is why it has so many commits - they should be hidden after it's merged? Let's see how clever GitHub is. Regardless, I've left it as draft in case you add more changes to #3 before you merge this.