### PR TITLE
No fallible casts

### DIFF
--- a/src/c_abi/mod.rs
+++ b/src/c_abi/mod.rs
@@ -1,3 +1,4 @@
+//! # Low level bindings to the c library from GROMACS
 #![allow(non_upper_case_globals, non_camel_case_types)]
 
 pub mod xdr_seek;

--- a/src/c_abi/xdrfile.rs
+++ b/src/c_abi/xdrfile.rs
@@ -6,21 +6,20 @@ pub struct XDRFILE {
     _unused: [u8; 0],
 }
 
-pub type BindgenTy1 = u32;
-pub const exdrOK: BindgenTy1 = 0;
-pub const exdrHEADER: BindgenTy1 = 1;
-pub const exdrSTRING: BindgenTy1 = 2;
-pub const exdrDOUBLE: BindgenTy1 = 3;
-pub const exdrINT: BindgenTy1 = 4;
-pub const exdrFLOAT: BindgenTy1 = 5;
-pub const exdrUINT: BindgenTy1 = 6;
-pub const exdr3DX: BindgenTy1 = 7;
-pub const exdrCLOSE: BindgenTy1 = 8;
-pub const exdrMAGIC: BindgenTy1 = 9;
-pub const exdrNOMEM: BindgenTy1 = 10;
-pub const exdrENDOFFILE: BindgenTy1 = 11;
-pub const exdrFILENOTFOUND: BindgenTy1 = 12;
-pub const exdrNR: BindgenTy1 = 13;
+pub const exdrOK: i32 = 0;
+pub const exdrHEADER: i32 = 1;
+pub const exdrSTRING: i32 = 2;
+pub const exdrDOUBLE: i32 = 3;
+pub const exdrINT: i32 = 4;
+pub const exdrFLOAT: i32 = 5;
+pub const exdrUINT: i32 = 6;
+pub const exdr3DX: i32 = 7;
+pub const exdrCLOSE: i32 = 8;
+pub const exdrMAGIC: i32 = 9;
+pub const exdrNOMEM: i32 = 10;
+pub const exdrENDOFFILE: i32 = 11;
+pub const exdrFILENOTFOUND: i32 = 12;
+pub const exdrNR: i32 = 13;
 
 extern "C" {
     pub static mut exdr_message: [*mut ::std::os::raw::c_char; 13usize];

--- a/src/c_abi/xdrfile_trr.rs
+++ b/src/c_abi/xdrfile_trr.rs
@@ -65,7 +65,7 @@ mod tests {
 
         unsafe {
             let code = read_trr_nframes(path.as_ptr(), &mut nframes);
-            assert!(code as u32 == exdrOK);
+            assert!(code == exdrOK);
         }
         assert!(nframes == 38, "{:?}", nframes);
         Ok(())
@@ -106,7 +106,7 @@ mod tests {
                 v.as_ptr() as *mut Rvec,
                 f.as_ptr() as *mut Rvec,
             );
-            assert!(write_code as u32 == exdrOK);
+            assert!(write_code == exdrOK);
             xdrfile_close(xdr);
         }
 
@@ -134,7 +134,7 @@ mod tests {
                 v2.as_ptr() as *mut Rvec,
                 f2.as_ptr() as *mut Rvec,
             );
-            assert!(read_code as u32 == exdrOK);
+            assert!(read_code == exdrOK);
             xdrfile_close(xdr);
         }
 

--- a/src/c_abi/xdrfile_xtc.rs
+++ b/src/c_abi/xdrfile_xtc.rs
@@ -61,7 +61,7 @@ mod tests {
 
         unsafe {
             let code = read_xtc_nframes(path.as_ptr(), &mut nframes);
-            assert!(code as u32 == exdrOK);
+            assert!(code == exdrOK);
         }
         assert!(nframes == 38, "{:?}", nframes);
         Ok(())
@@ -96,7 +96,7 @@ mod tests {
                 x.as_ptr() as *mut Rvec,
                 1000.0,
             );
-            assert!(write_code as u32 == exdrOK);
+            assert!(write_code == exdrOK);
             xdrfile_close(xdr);
         }
 
@@ -119,7 +119,7 @@ mod tests {
                 x2.as_ptr() as *mut Rvec,
                 &mut prec,
             );
-            assert!(read_code as u32 == exdrOK);
+            assert!(read_code == exdrOK);
             xdrfile_close(xdr);
         }
 

--- a/src/c_abi/xdrfile_xtc.rs
+++ b/src/c_abi/xdrfile_xtc.rs
@@ -29,8 +29,8 @@ extern "C" {
         natoms: ::std::os::raw::c_int,
         step: ::std::os::raw::c_int,
         time: ::std::os::raw::c_float,
-        box_vec: *mut Matrix,
-        x: *mut Rvec,
+        box_vec: *const Matrix,
+        x: *const Rvec,
         prec: ::std::os::raw::c_float,
     ) -> ::std::os::raw::c_int;
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,6 @@
 use crate::c_abi;
 use crate::FileMode;
 use crate::Frame;
-use std::convert::TryInto;
 use std::error::Error as StdError;
 use std::path::{Path, PathBuf};
 
@@ -206,7 +205,7 @@ pub enum ErrorCode {
     /// Failed to seek within file
     ExdrNr,
     /// Something unexpected happened
-    UnmatchedCode(c_abi::xdrfile::BindgenTy1),
+    UnmatchedCode(i32),
 }
 
 impl ErrorCode {
@@ -216,13 +215,9 @@ impl ErrorCode {
     }
 }
 
-impl<T> From<T> for ErrorCode
-where
-    T: TryInto<c_abi::xdrfile::BindgenTy1>,
-    <T as TryInto<c_abi::xdrfile::BindgenTy1>>::Error: std::fmt::Debug,
-{
-    fn from(code: T) -> Self {
-        match code.try_into().expect("C API return code was out of range") {
+impl From<i32> for ErrorCode {
+    fn from(code: i32) -> Self {
+        match code {
             c_abi::xdrfile::exdrOK => Self::ExdrOk,
             c_abi::xdrfile::exdrHEADER => Self::ExdrHeader,
             c_abi::xdrfile::exdrSTRING => Self::ExdrString,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,6 +2,7 @@ use crate::c_abi;
 use crate::FileMode;
 use crate::Frame;
 use std::error::Error as StdError;
+use std::os::raw::c_int;
 use std::path::{Path, PathBuf};
 
 /// Error type for the xdrfile library
@@ -35,6 +36,8 @@ pub enum Error {
         task: ErrorTask,
         value: usize,
     },
+    /// A numeric cast from `value` failed during `task`
+    NumAtomsOutOfRange(c_int),
 }
 
 impl Error {
@@ -134,10 +137,12 @@ impl std::fmt::Display for Error {
             CouldNotCheckNAtoms(_err) => {
                 write!(f, "Failed to read number of atoms in trajectory file")
             }
-            StepSizeOutOfRange(n) => write!(f, "Step {} does not fit in usize on this platform", n),
+            StepSizeOutOfRange(n) | NumAtomsOutOfRange(n) => {
+                write!(f, "Step {} does not fit in usize on this platform", n)
+            }
             CastToCintFailed { value, task, .. } => write!(
                 f,
-                "Numeric cast from {value}:usize to i32 failed while {task}",
+                "Numeric cast from {value}:usize to C int failed while {task}",
                 value = value,
                 task = task
             ),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,15 +29,15 @@ pub enum Error {
     NullInStr(std::ffi::NulError),
     CouldNotCheckNAtoms(Box<Error>),
     /// Step was out of range for usize on this platform
-    StepSizeOutOfRange(i32),
+    StepOutOfRange(i32),
+    /// natoms was out of range for usize on this platform
+    NumAtomsOutOfRange(c_int),
     /// A numeric cast from `value` failed during `task`
     CastToCintFailed {
         source: std::num::TryFromIntError,
         task: ErrorTask,
         value: usize,
     },
-    /// A numeric cast from `value` failed during `task`
-    NumAtomsOutOfRange(c_int),
 }
 
 impl Error {
@@ -137,9 +137,16 @@ impl std::fmt::Display for Error {
             CouldNotCheckNAtoms(_err) => {
                 write!(f, "Failed to read number of atoms in trajectory file")
             }
-            StepSizeOutOfRange(n) | NumAtomsOutOfRange(n) => {
-                write!(f, "Step {} does not fit in usize on this platform", n)
-            }
+            StepOutOfRange(n) => write!(
+                f,
+                "Illegal step size while reading trajectory: Failed to cast {} to usize.",
+                n
+            ),
+            NumAtomsOutOfRange(n) => write!(
+                f,
+                "Illegal number of atoms while reading trajectory: Failed to cast {} to usize.",
+                n
+            ),
             CastToCintFailed { value, task, .. } => write!(
                 f,
                 "Numeric cast from {value}:usize to C int failed while {task}",

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,7 +30,7 @@ pub enum Error {
     /// Step was out of range for usize on this platform
     StepSizeOutOfRange(i32),
     /// A numeric cast from `value` failed during `task`
-    CastFromI32Failed {
+    CastToCintFailed {
         source: std::num::TryFromIntError,
         task: ErrorTask,
         value: usize,
@@ -72,7 +72,7 @@ impl std::error::Error for Error {
         match &self {
             NullInStr(err) => Some(err),
             CouldNotCheckNAtoms(err) => Some(err.as_ref()),
-            CastFromI32Failed { source, .. } => Some(source),
+            CastToCintFailed { source, .. } => Some(source),
             _ => None,
         }
     }
@@ -135,7 +135,7 @@ impl std::fmt::Display for Error {
                 write!(f, "Failed to read number of atoms in trajectory file")
             }
             StepSizeOutOfRange(n) => write!(f, "Step {} does not fit in usize on this platform", n),
-            CastFromI32Failed { value, task, .. } => write!(
+            CastToCintFailed { value, task, .. } => write!(
                 f,
                 "Numeric cast from {value}:usize to i32 failed while {task}",
                 value = value,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,7 +30,7 @@ pub enum Error {
     /// Step was out of range for usize on this platform
     StepSizeOutOfRange(i32),
     /// A numeric cast from `value` failed during `task`
-    NumericCastFailed {
+    CastFromI32Failed {
         source: std::num::TryFromIntError,
         task: ErrorTask,
         value: usize,
@@ -72,7 +72,7 @@ impl std::error::Error for Error {
         match &self {
             NullInStr(err) => Some(err),
             CouldNotCheckNAtoms(err) => Some(err.as_ref()),
-            NumericCastFailed { source, .. } => Some(source),
+            CastFromI32Failed { source, .. } => Some(source),
             _ => None,
         }
     }
@@ -135,9 +135,9 @@ impl std::fmt::Display for Error {
                 write!(f, "Failed to read number of atoms in trajectory file")
             }
             StepSizeOutOfRange(n) => write!(f, "Step {} does not fit in usize on this platform", n),
-            NumericCastFailed { value, task, .. } => write!(
+            CastFromI32Failed { value, task, .. } => write!(
                 f,
-                "Numeric cast from {value} failed while {task}",
+                "Numeric cast from {value}:usize to i32 failed while {task}",
                 value = value,
                 task = task
             ),

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -28,9 +28,7 @@ impl Default for Frame {
 impl Frame {
     /// Creates an empty frame with a capacity of 0
     pub fn new() -> Frame {
-        Frame {
-            ..Default::default()
-        }
+        Default::default()
     }
 
     /// Creates a frame with the given capacity
@@ -55,6 +53,11 @@ impl Frame {
 
     /// Length of the frame (number of atoms)
     pub fn len(self: &Frame) -> usize {
+        self.num_atoms()
+    }
+
+    /// The number of atoms in the frame
+    pub fn num_atoms(self: &Frame) -> usize {
         self.coords.len()
     }
 

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -32,11 +32,10 @@ impl IntoIterator for TRRTrajectory {
     }
 }
 
-/*
-Iterator for trajectories. This iterator yields a Result<Frame, Error>
-for each frame in the trajectory file and stops with yielding None once the
-trajectory is finished. Also yields None after the first occurence of an error
-*/
+/// Iterator for trajectories.
+/// This iterator yields a Result<Frame, Error> for each frame in the
+/// trajectory file and stops with yielding None once the trajectory is
+/// EOF. Also yields None after the first occurrence of an error
 pub struct TrajectoryIterator<T> {
     trajectory: T,
     item: Rc<Frame>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -816,6 +816,13 @@ mod tests {
         });
         assert_eq!(expected, to!(big_number, ErrorTask::Write));
 
+        let num_atoms: usize = 304;
+        let res: Result<u8, _> = to!(num_atoms, ErrorTask::Write);
+        assert_eq!(
+            format!("{}", res.unwrap_err()),
+            "Illegal num_atoms while writing trajectory: Failed to cast 304 to u8"
+        );
+
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ impl Trajectory for XTCTrajectory {
             if let Some(err) = check_code(code, ErrorTask::Read) {
                 return Err(err);
             }
-            frame.step = usize::try_from(step).map_err(|_| Error::StepSizeOutOfRange(step))?;
+            frame.step = usize::try_from(step).map_err(|_| Error::StepOutOfRange(step))?;
             Ok(())
         }
     }
@@ -406,7 +406,7 @@ impl Trajectory for TRRTrajectory {
             if let Some(err) = check_code(code, ErrorTask::Read) {
                 return Err(err);
             }
-            frame.step = usize::try_from(step).map_err(|_| Error::StepSizeOutOfRange(step))?;
+            frame.step = usize::try_from(step).map_err(|_| Error::StepOutOfRange(step))?;
             Ok(())
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,8 +289,8 @@ impl Trajectory for XTCTrajectory {
                 to_c_int(frame.len(), ErrorTask::Write)?,
                 to_c_int(frame.step, ErrorTask::Write)?,
                 frame.time,
-                frame.box_vector.as_ptr() as *mut [[f32; 3]; 3],
-                frame.coords[..].as_ptr() as *mut [f32; 3],
+                &frame.box_vector,
+                frame.coords.as_ptr(),
                 1000.0,
             );
             if let Some(err) = check_code(code, ErrorTask::Write) {
@@ -320,7 +320,7 @@ impl Trajectory for XTCTrajectory {
                 unsafe {
                     let path = path_to_cstring(&self.handle.path)?;
                     let path_p = path.into_raw();
-                    let code = xdrfile_xtc::read_xtc_natoms(path_p, &mut num_atoms as *const c_int);
+                    let code = xdrfile_xtc::read_xtc_natoms(path_p, &mut num_atoms);
                     // Reconstitute the CString so it is deallocated correctly
                     let _ = CString::from_raw(path_p);
 
@@ -420,8 +420,8 @@ impl Trajectory for TRRTrajectory {
                 to_c_int(frame.step, ErrorTask::Write)?,
                 frame.time,
                 0.0,
-                frame.box_vector.as_ptr() as *mut [[f32; 3]; 3],
-                frame.coords[..].as_ptr() as *mut [f32; 3],
+                &frame.box_vector,
+                frame.coords[..].as_ptr(),
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
             );
@@ -451,7 +451,7 @@ impl Trajectory for TRRTrajectory {
                 unsafe {
                     let path = path_to_cstring(&self.handle.path)?;
                     let path_p = path.into_raw();
-                    let code = xdrfile_trr::read_trr_natoms(path_p, &mut num_atoms as *const c_int);
+                    let code = xdrfile_trr::read_trr_natoms(path_p, &mut num_atoms);
                     // Reconstitute the CString so it is deallocated correctly
                     let _ = CString::from_raw(path_p);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -835,4 +835,33 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_write_outofrange_step() -> Result<(), Box<dyn std::error::Error>> {
+        let tempfile = NamedTempFile::new()?;
+        let tmp_path = tempfile.path();
+        let mut traj = XTCTrajectory::open_write(tmp_path)?;
+
+        let frame = Frame {
+            step: usize::MAX,
+            time: 0.0,
+            box_vector: [[0.0; 3]; 3],
+            coords: vec![[1.0; 3]],
+        };
+        let expected = Error::OutOfRange {
+            name: "frame.step",
+            value: usize::MAX.to_string(),
+            target: "i32",
+            task: ErrorTask::Write,
+        };
+
+        if let Err(e) = traj.write(&frame) {
+            print!("{:?}", e);
+            assert_eq!(expected, e);
+        } else {
+            panic!("Writing frame with step=usize::MAX should not succeed.")
+        }
+
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,7 @@ impl Trajectory for XTCTrajectory {
             if let Some(err) = check_code(code, ErrorTask::Read) {
                 return Err(err);
             }
-            frame.step = to!(step, ErrorTask::ReadNumAtoms)?;
+            frame.step = to!(step, ErrorTask::Read)?;
             Ok(())
         }
     }
@@ -314,7 +314,7 @@ impl Trajectory for XTCTrajectory {
     fn flush(&mut self) -> Result<()> {
         unsafe {
             let code = xdr_seek::xdr_flush(self.handle.xdrfile);
-            if let Some(err) = check_code(code, ErrorTask::Read) {
+            if let Some(err) = check_code(code, ErrorTask::Flush) {
                 Err(err)
             } else {
                 Ok(())
@@ -416,7 +416,7 @@ impl Trajectory for TRRTrajectory {
             if let Some(err) = check_code(code, ErrorTask::Read) {
                 return Err(err);
             }
-            frame.step = to!(step, ErrorTask::ReadNumAtoms)?;
+            frame.step = to!(step, ErrorTask::Read)?;
             Ok(())
         }
     }
@@ -807,13 +807,14 @@ mod tests {
     fn test_to() -> Result<()> {
         assert_eq!(24234_i32, to!(24234_usize, ErrorTask::Write)?);
 
+        let big_number = 3_294_967_295_usize;
         let expected: Result<i32> = Err(Error::OutOfRange {
-            name: "3_294_967_295_usize",
+            name: "big_number",
             task: ErrorTask::Write,
             value: "3294967295".to_string(),
             target: "i32",
         });
-        assert_eq!(expected, to!(3_294_967_295_usize, ErrorTask::Write));
+        assert_eq!(expected, to!(big_number, ErrorTask::Write));
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,8 +327,7 @@ impl Trajectory for XTCTrajectory {
                     if let Some(err) = check_code(code, ErrorTask::ReadNumAtoms) {
                         Err(err)
                     } else {
-                        Ok(usize::try_from(num_atoms)
-                            .expect("Number of atoms in file does not fit in usize"))
+                        usize::try_from(num_atoms).map_err(|_| Error::NumAtomsOutOfRange(num_atoms))
                     }
                 }
             })
@@ -458,8 +457,7 @@ impl Trajectory for TRRTrajectory {
                     if let Some(err) = check_code(code, ErrorTask::ReadNumAtoms) {
                         Err(err)
                     } else {
-                        Ok(usize::try_from(num_atoms)
-                            .expect("Number of atoms in file does not fit in usize"))
+                        usize::try_from(num_atoms).map_err(|_| Error::NumAtomsOutOfRange(num_atoms))
                     }
                 }
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ macro_rules! to {
 /// `code` should be an integer return code returned from the C API.
 /// If `code` indicates the function returned successfully, None is returned;
 /// otherwise, the code is converted into the appropriate `Error`.
-pub fn check_code(code: impl Into<ErrorCode>, task: ErrorTask) -> Option<Error> {
+fn check_code(code: impl Into<ErrorCode>, task: ErrorTask) -> Option<Error> {
     let code: ErrorCode = code.into();
     if let ErrorCode::ExdrOk = code {
         None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ fn path_to_cstring(path: impl AsRef<Path>) -> Result<CString> {
 }
 
 fn to_i32(value: usize, task: ErrorTask) -> Result<i32> {
-    value.try_into().map_err(|e| Error::NumericCastFailed {
+    value.try_into().map_err(|e| Error::CastFromI32Failed {
         source: e,
         value,
         task,
@@ -809,7 +809,7 @@ mod tests {
             Err(e) => e,
             _ => panic!("Conversion from -1 to u8 succeeded"),
         };
-        let expected = Error::NumericCastFailed {
+        let expected = Error::CastFromI32Failed {
             source: try_from_int_err,
             task: ErrorTask::Write,
             value: 3_294_967_295_usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ fn to_i32(value: usize, task: ErrorTask) -> Result<i32> {
 /// Convert an error code from a C call to an Error
 ///
 /// `code` should be an integer return code returned from the C API.
-/// If `code` indicates the function returned successfully, Nothing is returned;
+/// If `code` indicates the function returned successfully, None is returned;
 /// otherwise, the code is converted into the appropriate `Error`.
 pub fn check_code(code: impl Into<ErrorCode>, task: ErrorTask) -> Option<Error> {
     let code: ErrorCode = code.into();
@@ -797,5 +797,23 @@ mod tests {
             let code: ErrorCode = i.into();
             assert!(check_code(code, ErrorTask::Read).is_some());
         }
+    }
+
+    #[test]
+    fn test_to_i32() -> Result<()> {
+        assert_eq!(24234_i32, to_i32(24234_usize, ErrorTask::Read)?);
+
+        let try_from_int_err = match u8::try_from(-1) {
+            Err(e) => e,
+            _ => panic!("Conversion from -1 to u8 succeeded"),
+        };
+        let expected = Error::NumericCastFailed {
+            source: try_from_int_err,
+            task: ErrorTask::Write,
+            value: 3_294_967_295_usize,
+        };
+        assert_eq!(Err(expected), to_i32(3_294_967_295_usize, ErrorTask::Write));
+
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ use std::io::SeekFrom;
 use std::os::raw::{c_float, c_int};
 use std::path::{Path, PathBuf};
 
+/// File Mode for accessing trajectories.
 #[derive(Debug, Clone, PartialEq)]
 pub enum FileMode {
     Write,
@@ -233,7 +234,7 @@ pub trait Trajectory {
     fn get_num_atoms(&mut self) -> Result<usize>;
 }
 
-/// Read/Write XTC Trajectories
+/// Handle to Read/Write XTC Trajectories
 pub struct XTCTrajectory {
     handle: XDRFile,
     precision: Cell<c_float>, // internal mutability required for read method
@@ -361,7 +362,7 @@ impl io::Seek for XTCTrajectory {
     }
 }
 
-/// Read/Write TRR Trajectories
+/// Handle to Read/Write TRR Trajectories
 pub struct TRRTrajectory {
     handle: XDRFile,
     num_atoms: Lazy<Result<usize>>,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,7 +8,7 @@ mod integration {
     fn test_use_library() -> Result<()> {
         let mut trj = XTCTrajectory::open_read("tests/1l2y.xtc")?;
         let num_atoms = trj.get_num_atoms()?;
-        let mut frame = Frame::with_len(num_atoms as usize);
+        let mut frame = Frame::with_len(num_atoms);
 
         trj.read(&mut frame)?;
         trj.read(&mut frame)?;
@@ -21,7 +21,7 @@ mod integration {
         let trj = XTCTrajectory::open_read("tests/1l2y.xtc")?;
         let frames: Result<Vec<Rc<Frame>>> = trj.into_iter().collect();
         for (idx, frame) in frames?.iter().enumerate() {
-            assert_eq!(frame.step as usize, idx + 1);
+            assert_eq!(frame.step, idx + 1);
         }
         Ok(())
     }


### PR DESCRIPTION
All numeric casts using the `as` keyword throughout the library have been replaced (except for a few in `c_abi` tests). The problem with `as` is that it always succeeds; in theory this can lead to unexpected behaviour if, say, a negative `i32` somehow gets into an `xtc` file or a large `usize` gets interpreted as a negative `i32`. Failed casts will now give nice errors, or at least panic with an error message rather than succeed silently. If you think the errors are too much ado about something that is very unlikely to come up, I'm very happy to convert them all to panics - `usize::try_from(i).unwrap()` seems to be a standard way to handle these.

This PR is based on #6, which changes a few types. But I'll rebase everything as necessary based what you like/dislike etc.