### PR TITLE
Implement Drop for TRRTrajectory and XTCTrajectory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,6 +338,13 @@ impl Trajectory for XTCTrajectory {
     }
 }
 
+impl Drop for XTCTrajectory {
+    /// Try to flush the file on drop, ignoring errors
+    fn drop(&mut self) {
+        let _ = self.flush();
+    }
+}
+
 /// Read/Write TRR Trajectories
 pub struct TRRTrajectory {
     handle: XDRFile,
@@ -445,6 +452,13 @@ impl Trajectory for TRRTrajectory {
                 }
             })
             .clone()
+    }
+}
+
+impl Drop for TRRTrajectory {
+    /// Try to flush the file on drop, ignoring errors
+    fn drop(&mut self) {
+        let _ = self.flush();
     }
 }
 


### PR DESCRIPTION
Last one for tonight :) This one is so small it shouldn't need a rebase.

I genuinely don't know if this is a good idea or necessary or even does anything so I thought I'd get your input. I've implemented `Drop` for `XTCTrajectory` and `TRRTrajectory`. All it does is call flush and ignore any error that comes from that. This mimics [`std::io::BufWriter`](https://doc.rust-lang.org/src/std/io/buffered.rs.html#716-724). I figure if someone forgets to flush this might save their butt, and if someone's writing a script this saves a line. But I don't know if a flush is performed by `xdrfile_close` — it doesn't seem to be but C is hard and so are syscalls and this is both.

I do know that drop is called on a type before it is called on its fields, so in this case it'll flush and then close. ([API docs](https://doc.rust-lang.org/std/ops/trait.Drop.html), [reference](https://doc.rust-lang.org/reference/destructors.html))