### PR TITLE
Mode checks

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,6 +24,8 @@ pub enum Error {
         value: String,
         target: &'static str,
     },
+    /// Attempted to perform an unsupported operation given the file mode
+    WrongMode { mode: FileMode, task: ErrorTask },
 }
 
 impl Error {
@@ -64,7 +66,7 @@ impl std::error::Error for Error {
                 } else {
                     None
                 }
-            },
+            }
             Error::CouldNotCheckNAtoms(err) => Some(err.as_ref()),
             _ => None,
         }
@@ -132,6 +134,12 @@ impl std::fmt::Display for Error {
                 value = value,
                 target = target
             ),
+            Error::WrongMode { mode, task } => write!(
+                f,
+                "{task} is impossible with file mode {mode:?}",
+                mode = mode,
+                task = task.uppercase_first(),
+            ),
         }
     }
 }
@@ -149,6 +157,14 @@ pub enum ErrorTask {
     Flush,
     /// A seek operation was being run on a file
     Seek,
+}
+
+impl ErrorTask {
+    fn uppercase_first(&self) -> String {
+        let mut s = format!("{}", self);
+        &mut s[0..1].make_ascii_uppercase();
+        s
+    }
 }
 
 impl std::fmt::Display for ErrorTask {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,6 +268,11 @@ impl XTCTrajectory {
     pub fn open_write(path: impl AsRef<Path>) -> Result<Self> {
         Self::open(path, FileMode::Write)
     }
+
+    /// The mode the current file is open in
+    pub fn file_mode(&self) -> FileMode {
+        self.handle.filemode
+    }
 }
 
 impl Trajectory for XTCTrajectory {
@@ -417,6 +422,11 @@ impl TRRTrajectory {
     /// Open a file in write mode
     pub fn open_write(path: impl AsRef<Path>) -> Result<Self> {
         Self::open(path, FileMode::Write)
+    }
+
+    /// The mode the current file is open in
+    pub fn file_mode(&self) -> FileMode {
+        self.handle.filemode
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,10 @@ use std::convert::{TryFrom, TryInto};
 use std::ffi::CString;
 use std::io;
 use std::io::SeekFrom;
+use std::marker::PhantomData;
 use std::os::raw::{c_float, c_int};
 use std::path::{Path, PathBuf};
+use std::ptr::NonNull;
 
 /// File Mode for accessing trajectories.
 #[derive(Debug, Clone, PartialEq)]
@@ -147,7 +149,8 @@ fn check_code(code: impl Into<ErrorCode>, task: ErrorTask) -> Option<Error> {
 
 /// A safe wrapper around the c implementation of an XDRFile
 struct XDRFile {
-    xdrfile: *mut XDRFILE,
+    xdrfile: NonNull<XDRFILE>,
+    _owned: PhantomData<XDRFILE>,
     #[allow(dead_code)]
     filemode: FileMode,
     path: PathBuf,
@@ -166,10 +169,11 @@ impl XDRFile {
             // Reconstitute the CString so it is deallocated correctly
             let _ = CString::from_raw(path_p);
 
-            if !xdrfile.is_null() {
+            if let Some(xdrfile) = NonNull::new(xdrfile) {
                 let path = path.to_owned();
                 Ok(XDRFile {
                     xdrfile,
+                    _owned: PhantomData,
                     filemode,
                     path,
                 })
@@ -183,7 +187,7 @@ impl XDRFile {
     /// Get the current position in the file
     pub fn tell(&self) -> u64 {
         unsafe {
-            xdr_seek::xdr_tell(self.xdrfile)
+            xdr_seek::xdr_tell(self.xdrfile.as_ptr())
                 .try_into()
                 .expect("i64 could not be converted to u64")
         }
@@ -201,7 +205,7 @@ impl io::Seek for XDRFile {
             SeekFrom::End(i) => (2, i),
         };
         unsafe {
-            let code = xdr_seek::xdr_seek(self.xdrfile, pos, whence);
+            let code = xdr_seek::xdr_seek(self.xdrfile.as_ptr(), pos, whence);
             match check_code(code, ErrorTask::Seek) {
                 None => Ok(self.tell()),
                 Some(err) => Err(io::Error::new(io::ErrorKind::Other, err)),
@@ -214,7 +218,7 @@ impl Drop for XDRFile {
     /// Close the underlying xdr file on drop
     fn drop(&mut self) {
         unsafe {
-            xdrfile::xdrfile_close(self.xdrfile);
+            xdrfile::xdrfile_close(self.xdrfile.as_ptr());
         }
     }
 }
@@ -280,7 +284,7 @@ impl Trajectory for XTCTrajectory {
 
         unsafe {
             let code = xdrfile_xtc::read_xtc(
-                self.handle.xdrfile,
+                self.handle.xdrfile.as_ptr(),
                 to!(num_atoms, ErrorTask::Read)?,
                 &mut step,
                 &mut frame.time,
@@ -299,7 +303,7 @@ impl Trajectory for XTCTrajectory {
     fn write(&mut self, frame: &Frame) -> Result<()> {
         unsafe {
             let code = xdrfile_xtc::write_xtc(
-                self.handle.xdrfile,
+                self.handle.xdrfile.as_ptr(),
                 to!(frame.num_atoms(), ErrorTask::Write)?,
                 to!(frame.step, ErrorTask::Write)?,
                 frame.time,
@@ -317,7 +321,7 @@ impl Trajectory for XTCTrajectory {
 
     fn flush(&mut self) -> Result<()> {
         unsafe {
-            let code = xdr_seek::xdr_flush(self.handle.xdrfile);
+            let code = xdr_seek::xdr_flush(self.handle.xdrfile.as_ptr());
             if let Some(err) = check_code(code, ErrorTask::Flush) {
                 Err(err)
             } else {
@@ -407,7 +411,7 @@ impl Trajectory for TRRTrajectory {
 
         unsafe {
             let code = xdrfile_trr::read_trr(
-                self.handle.xdrfile,
+                self.handle.xdrfile.as_ptr(),
                 to!(num_atoms, ErrorTask::Read)?,
                 &mut step,
                 &mut frame.time,
@@ -428,7 +432,7 @@ impl Trajectory for TRRTrajectory {
     fn write(&mut self, frame: &Frame) -> Result<()> {
         unsafe {
             let code = xdrfile_trr::write_trr(
-                self.handle.xdrfile,
+                self.handle.xdrfile.as_ptr(),
                 to!(frame.len(), ErrorTask::Write)?,
                 to!(frame.step, ErrorTask::Write)?,
                 frame.time,
@@ -448,7 +452,7 @@ impl Trajectory for TRRTrajectory {
 
     fn flush(&mut self) -> Result<()> {
         unsafe {
-            let code = xdr_seek::xdr_flush(self.handle.xdrfile);
+            let code = xdr_seek::xdr_flush(self.handle.xdrfile.as_ptr());
             if let Some(err) = check_code(code, ErrorTask::Flush) {
                 Err(err)
             } else {


### PR DESCRIPTION
Two changes: 

1. `XDRFile.xdrfile` is know a `NonNull<XDRFILE>` rather than a `*mut XDRFILE`, and a PhantomData field was added. `NonNull` allows a null value to be used as the discriminant in `Option<XDRFile>`, and the PhantomData makes sure that drop checks, send + sync derivation, anything Rust adds in the future etc treat `XDRFile` as owning an `XDRFILE`

2. `Trajectory::read()`, `write()` and `flush()` now check that the mode is correct before passing to C. C doesn't actually check this, so there were some pretty cryptic errors when it failed. Now the messages are nice and clear! The trajectory types also have `file_mode()` functions now.

I think there might be scope for splitting the `Trajectory` trait into `TrajectoryWriter` and `TrajectoryReader`, and have separate types for writing and reading. With the `open_read` etc methods the type system can know what's going on, after all. What do you think?