### PR TITLE
Mode types

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -1,14 +1,14 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::rc::Rc;
+use std::time::Duration;
 use tempfile::NamedTempFile;
 use xdrfile::*;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use std::time::Duration;
 
 /// generate a temporary test trajectory of given length
 fn gen_test_traj(num_atoms: usize, num_frames: usize) -> Result<NamedTempFile> {
     let tempfile = NamedTempFile::new().expect("Could not create temporary file");
     let tmp_path = tempfile.path().to_path_buf();
-    let mut f = XTCTrajectory::open_write(&tmp_path)?;
+    let mut f = XtcTrajectory::open_write(&tmp_path)?;
 
     let mut frame = Frame {
         step: 1,
@@ -28,14 +28,14 @@ fn gen_test_traj(num_atoms: usize, num_frames: usize) -> Result<NamedTempFile> {
         f.write(&frame)?;
     }
     f.flush()?;
- 
+
     Ok(tempfile)
 }
 
 // Iterate over a trajectory and do some stuff on it
 fn iterate_traj(file: &NamedTempFile, num_atoms: usize) -> Result<()> {
     let path = file.path();
-    let traj = XTCTrajectory::open_read(path)?;
+    let traj = XtcTrajectory::open_read(path)?;
     for frame in traj.into_iter() {
         assert_eq!(frame?.len(), num_atoms);
     }
@@ -46,8 +46,11 @@ fn iterate_traj(file: &NamedTempFile, num_atoms: usize) -> Result<()> {
 // This benchmarks iteration speed when frames are not reused
 fn iterate_traj_keep_frames(file: &NamedTempFile, num_frames: usize) -> Result<()> {
     let path = file.path();
-    let traj = XTCTrajectory::open_read(path)?;
-    let frames = traj.into_iter().filter_map(Result::ok).collect::<Vec<Rc<Frame>>>();
+    let traj = XtcTrajectory::open_read(path)?;
+    let frames = traj
+        .into_iter()
+        .filter_map(Result::ok)
+        .collect::<Vec<Rc<Frame>>>();
     assert_eq!(num_frames, frames.len());
     Ok(())
 }
@@ -58,18 +61,18 @@ fn bench_iterate_traj(c: &mut Criterion) {
     let tempfile = gen_test_traj(num_atoms, num_frames).unwrap();
 
     let mut group = c.benchmark_group("iterate_traj");
-    group.significance_level(0.05)
-         .warm_up_time(Duration::from_secs(10))
-         .sample_size(2500)
-         .noise_threshold(0.05);  // high noise thresholds because of disk i/o
-    group.bench_function("iterate_traj", |b| b.iter(|| {
-        iterate_traj(black_box(&tempfile), black_box(num_atoms)).unwrap()
-    }));
-    group.bench_function("iterate_traj_keep_frames", |b| b.iter(|| {
-        iterate_traj_keep_frames(black_box(&tempfile), black_box(num_frames)).unwrap()
-    }));
+    group
+        .significance_level(0.05)
+        .warm_up_time(Duration::from_secs(10))
+        .sample_size(2500)
+        .noise_threshold(0.05); // high noise thresholds because of disk i/o
+    group.bench_function("iterate_traj", |b| {
+        b.iter(|| iterate_traj(black_box(&tempfile), black_box(num_atoms)).unwrap())
+    });
+    group.bench_function("iterate_traj_keep_frames", |b| {
+        b.iter(|| iterate_traj_keep_frames(black_box(&tempfile), black_box(num_frames)).unwrap())
+    });
 }
 
 criterion_group!(benches, bench_iterate_traj);
 criterion_main!(benches);
-

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -245,6 +245,24 @@ pub enum ErrorFileMode {
     Append,
 }
 
+impl From<filemode::Read> for ErrorFileMode {
+    fn from(_: filemode::Read) -> Self {
+        Self::Read
+    }
+}
+
+impl From<filemode::Write> for ErrorFileMode {
+    fn from(_: filemode::Write) -> Self {
+        Self::Write
+    }
+}
+
+impl From<filemode::Append> for ErrorFileMode {
+    fn from(_: filemode::Append) -> Self {
+        Self::Append
+    }
+}
+
 /// `Result` type for errors in the `xdrfile` crate
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,11 +24,6 @@ pub enum Error {
         value: String,
         target: &'static str,
     },
-    /// Attempted to perform an unsupported operation given the file mode
-    WrongMode {
-        mode: ErrorFileMode,
-        task: ErrorTask,
-    },
 }
 
 impl Error {
@@ -137,12 +132,6 @@ impl std::fmt::Display for Error {
                 value = value,
                 target = target
             ),
-            Error::WrongMode { mode, task } => write!(
-                f,
-                "{task} is impossible with file mode {mode:?}",
-                mode = mode,
-                task = task.uppercase_first(),
-            ),
         }
     }
 }
@@ -160,14 +149,6 @@ pub enum ErrorTask {
     Flush,
     /// A seek operation was being run on a file
     Seek,
-}
-
-impl ErrorTask {
-    fn uppercase_first(&self) -> String {
-        let mut s = format!("{}", self);
-        &mut s[0..1].make_ascii_uppercase();
-        s
-    }
 }
 
 impl std::fmt::Display for ErrorTask {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
 use crate::c_abi;
-use crate::FileMode;
+use crate::filemode;
 use crate::Frame;
 use std::error::Error as StdError;
 use std::path::{Path, PathBuf};
@@ -12,7 +12,7 @@ pub enum Error {
     /// Passed in a frame of the wrong size
     WrongSizeFrame { expected: usize, found: usize },
     /// C API failed to open a file (No return code provided)
-    CouldNotOpen { path: PathBuf, mode: FileMode },
+    CouldNotOpen { path: PathBuf, mode: ErrorFileMode },
     /// A path could not be converted to &OsStr
     InvalidOsStr(Option<std::ffi::NulError>),
     /// Checking the number of atoms failed while reading a frame
@@ -23,6 +23,11 @@ pub enum Error {
         task: ErrorTask,
         value: String,
         target: &'static str,
+    },
+    /// Attempted to perform an unsupported operation given the file mode
+    WrongMode {
+        mode: ErrorFileMode,
+        task: ErrorTask,
     },
 }
 
@@ -78,12 +83,12 @@ impl From<(ErrorCode, ErrorTask)> for Error {
     }
 }
 
-impl From<(&Path, FileMode)> for Error {
-    fn from(value: (&Path, FileMode)) -> Self {
+impl<M: filemode::FileMode> From<(&Path, M)> for Error {
+    fn from(value: (&Path, M)) -> Self {
         let (path, mode) = value;
         Error::CouldNotOpen {
             path: path.to_owned(),
-            mode,
+            mode: mode.into(),
         }
     }
 }
@@ -132,6 +137,12 @@ impl std::fmt::Display for Error {
                 value = value,
                 target = target
             ),
+            Error::WrongMode { mode, task } => write!(
+                f,
+                "{task} is impossible with file mode {mode:?}",
+                mode = mode,
+                task = task.uppercase_first(),
+            ),
         }
     }
 }
@@ -149,6 +160,14 @@ pub enum ErrorTask {
     Flush,
     /// A seek operation was being run on a file
     Seek,
+}
+
+impl ErrorTask {
+    fn uppercase_first(&self) -> String {
+        let mut s = format!("{}", self);
+        &mut s[0..1].make_ascii_uppercase();
+        s
+    }
 }
 
 impl std::fmt::Display for ErrorTask {
@@ -237,6 +256,14 @@ impl std::fmt::Display for ErrorCode {
     }
 }
 
+/// Allow file modes to be represented as errors without a generic error type
+#[derive(Debug, Clone, PartialEq, Copy)]
+pub enum ErrorFileMode {
+    Read,
+    Write,
+    Append,
+}
+
 /// `Result` type for errors in the `xdrfile` crate
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -278,7 +305,7 @@ mod tests {
 
         let error = Error::CouldNotOpen {
             path: PathBuf::from("not/a/file"),
-            mode: FileMode::Read,
+            mode: ErrorFileMode::Read,
         };
         assert!(!error.is_eof());
     }
@@ -292,10 +319,10 @@ mod tests {
         assert_eq!(expected, err);
 
         let path = Path::new(".");
-        let mode = FileMode::Read;
+        let mode = filemode::Read;
         let expected = Error::CouldNotOpen {
             path: path.to_path_buf(),
-            mode: mode.to_owned(),
+            mode: ErrorFileMode::Read,
         };
         let err = Error::from((path, mode));
         assert_eq!(expected, err);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -78,7 +78,7 @@ impl From<(ErrorCode, ErrorTask)> for Error {
     }
 }
 
-impl<M: filemode::FileMode> From<(&Path, M)> for Error {
+impl<M: filemode::FileMode + Into<ErrorFileMode>> From<(&Path, M)> for Error {
     fn from(value: (&Path, M)) -> Self {
         let (path, mode) = value;
         Error::CouldNotOpen {

--- a/src/filemode.rs
+++ b/src/filemode.rs
@@ -1,0 +1,60 @@
+use crate::errors::ErrorFileMode;
+
+/// Trait for all file modes
+pub trait FileMode: Default + Into<ErrorFileMode> {
+    /// Get a CStr slice corresponding to the file mode
+    fn to_cstr() -> &'static std::ffi::CStr;
+}
+
+/// The read-only mode
+#[derive(Debug, Clone, PartialEq, Copy, Default)]
+pub struct Read;
+/// The write-only mode
+#[derive(Debug, Clone, PartialEq, Copy, Default)]
+pub struct Write;
+/// The read/write append mode
+#[derive(Debug, Clone, PartialEq, Copy, Default)]
+pub struct Append;
+
+impl FileMode for Read {
+    fn to_cstr() -> &'static std::ffi::CStr {
+        std::ffi::CStr::from_bytes_with_nul(b"r\0").expect("CStr::from_bytes_with_nul failed")
+    }
+}
+impl FileMode for Write {
+    fn to_cstr() -> &'static std::ffi::CStr {
+        std::ffi::CStr::from_bytes_with_nul(b"w\0").expect("CStr::from_bytes_with_nul failed")
+    }
+}
+impl FileMode for Append {
+    fn to_cstr() -> &'static std::ffi::CStr {
+        std::ffi::CStr::from_bytes_with_nul(b"a\0").expect("CStr::from_bytes_with_nul failed")
+    }
+}
+
+/// Trait for modes that can read (read, append)
+pub trait ReaderMode: FileMode {}
+/// Trait for modes that can write (write, append)
+pub trait WriterMode: FileMode {}
+impl ReaderMode for Read {}
+impl ReaderMode for Append {}
+impl WriterMode for Append {}
+impl WriterMode for Write {}
+
+impl From<Read> for ErrorFileMode {
+    fn from(_: Read) -> Self {
+        Self::Read
+    }
+}
+
+impl From<Write> for ErrorFileMode {
+    fn from(_: Write) -> Self {
+        Self::Write
+    }
+}
+
+impl From<Append> for ErrorFileMode {
+    fn from(_: Append) -> Self {
+        Self::Append
+    }
+}

--- a/src/filemode.rs
+++ b/src/filemode.rs
@@ -1,5 +1,3 @@
-use crate::errors::ErrorFileMode;
-
 mod private {
     /// Prevent users from implementing FileMode on their own types
     ///
@@ -56,23 +54,5 @@ impl FileMode for Write {
 impl FileMode for Append {
     fn as_bytes_with_null() -> &'static [u8] {
         b"a\0"
-    }
-}
-
-impl From<Read> for ErrorFileMode {
-    fn from(_: Read) -> Self {
-        Self::Read
-    }
-}
-
-impl From<Write> for ErrorFileMode {
-    fn from(_: Write) -> Self {
-        Self::Write
-    }
-}
-
-impl From<Append> for ErrorFileMode {
-    fn from(_: Append) -> Self {
-        Self::Append
     }
 }

--- a/src/filemode.rs
+++ b/src/filemode.rs
@@ -43,15 +43,6 @@ impl FileMode for Append {
     }
 }
 
-/// Trait for modes that can read (read, append)
-pub trait ReaderMode: FileMode + private::Sealed {}
-/// Trait for modes that can write (write, append)
-pub trait WriterMode: FileMode + private::Sealed {}
-impl ReaderMode for Read {}
-impl ReaderMode for Append {}
-impl WriterMode for Append {}
-impl WriterMode for Write {}
-
 impl From<Read> for ErrorFileMode {
     fn from(_: Read) -> Self {
         Self::Read

--- a/src/filemode.rs
+++ b/src/filemode.rs
@@ -1,3 +1,5 @@
+//! Mode types for opening trajectory files
+
 mod private {
     /// Prevent users from implementing FileMode on their own types
     ///
@@ -13,7 +15,7 @@ mod private {
 ///
 /// FileMode is object safe:
 /// ```
-/// # use xdrfile::{FileMode, Read, Write, Append};
+/// # use xdrfile::filemode::{FileMode, Read, Write, Append};
 /// let trait_obj: Box<dyn FileMode> = Box::new(Read);
 /// ```
 pub trait FileMode: private::Sealed {

--- a/src/filemode.rs
+++ b/src/filemode.rs
@@ -1,7 +1,18 @@
 use crate::errors::ErrorFileMode;
 
+mod private {
+    /// Prevent users from implementing FileMode on their own types
+    ///
+    /// https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed
+    pub trait Sealed {}
+
+    impl Sealed for super::Read {}
+    impl Sealed for super::Write {}
+    impl Sealed for super::Append {}
+}
+
 /// Trait for all file modes
-pub trait FileMode: Default + Into<ErrorFileMode> {
+pub trait FileMode: Default + Into<ErrorFileMode> + private::Sealed {
     /// Get a CStr slice corresponding to the file mode
     fn to_cstr() -> &'static std::ffi::CStr;
 }
@@ -33,9 +44,9 @@ impl FileMode for Append {
 }
 
 /// Trait for modes that can read (read, append)
-pub trait ReaderMode: FileMode {}
+pub trait ReaderMode: FileMode + private::Sealed {}
 /// Trait for modes that can write (write, append)
-pub trait WriterMode: FileMode {}
+pub trait WriterMode: FileMode + private::Sealed {}
 impl ReaderMode for Read {}
 impl ReaderMode for Append {}
 impl WriterMode for Append {}

--- a/src/filemode.rs
+++ b/src/filemode.rs
@@ -12,9 +12,25 @@ mod private {
 }
 
 /// Trait for all file modes
-pub trait FileMode: Default + Into<ErrorFileMode> + private::Sealed {
+///
+/// FileMode is object safe:
+/// ```
+/// # use xdrfile::{FileMode, Read, Write, Append};
+/// let trait_obj: Box<dyn FileMode> = Box::new(Read);
+/// ```
+pub trait FileMode: private::Sealed {
+    fn as_bytes_with_null() -> &'static [u8]
+    where
+        Self: Sized;
+
     /// Get a CStr slice corresponding to the file mode
-    fn to_cstr() -> &'static std::ffi::CStr;
+    fn to_cstr() -> &'static std::ffi::CStr
+    where
+        Self: Sized,
+    {
+        std::ffi::CStr::from_bytes_with_nul(Self::as_bytes_with_null())
+            .expect("CStr::from_bytes_with_nul failed")
+    }
 }
 
 /// The read-only mode
@@ -28,18 +44,18 @@ pub struct Write;
 pub struct Append;
 
 impl FileMode for Read {
-    fn to_cstr() -> &'static std::ffi::CStr {
-        std::ffi::CStr::from_bytes_with_nul(b"r\0").expect("CStr::from_bytes_with_nul failed")
+    fn as_bytes_with_null() -> &'static [u8] {
+        b"r\0"
     }
 }
 impl FileMode for Write {
-    fn to_cstr() -> &'static std::ffi::CStr {
-        std::ffi::CStr::from_bytes_with_nul(b"w\0").expect("CStr::from_bytes_with_nul failed")
+    fn as_bytes_with_null() -> &'static [u8] {
+        b"w\0"
     }
 }
 impl FileMode for Append {
-    fn to_cstr() -> &'static std::ffi::CStr {
-        std::ffi::CStr::from_bytes_with_nul(b"a\0").expect("CStr::from_bytes_with_nul failed")
+    fn as_bytes_with_null() -> &'static [u8] {
+        b"a\0"
     }
 }
 

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -14,7 +14,7 @@ fn into_iter_inner<T: TrajectoryReader>(mut traj: T) -> TrajectoryIterator<T> {
     }
 }
 
-impl<R: filemode::ReaderMode> IntoIterator for XtcTrajectory<R> {
+impl IntoIterator for XtcTrajectory<Read> {
     type Item = Result<Rc<Frame>>;
     type IntoIter = TrajectoryIterator<Self>;
 
@@ -23,7 +23,25 @@ impl<R: filemode::ReaderMode> IntoIterator for XtcTrajectory<R> {
     }
 }
 
-impl<R: filemode::ReaderMode> IntoIterator for TrrTrajectory<R> {
+impl IntoIterator for TrrTrajectory<Read> {
+    type Item = Result<Rc<Frame>>;
+    type IntoIter = TrajectoryIterator<Self>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        into_iter_inner(self)
+    }
+}
+
+impl IntoIterator for XtcTrajectory<Append> {
+    type Item = Result<Rc<Frame>>;
+    type IntoIter = TrajectoryIterator<Self>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        into_iter_inner(self)
+    }
+}
+
+impl IntoIterator for TrrTrajectory<Append> {
     type Item = Result<Rc<Frame>>;
     type IntoIter = TrajectoryIterator<Self>;
 

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,3 +1,5 @@
+//! Iterator types for trajectories
+
 use crate::*;
 use std::rc::Rc;
 
@@ -14,7 +16,7 @@ fn into_iter_inner<T: TrajectoryReader>(mut traj: T) -> TrajectoryIterator<T> {
     }
 }
 
-impl IntoIterator for XtcTrajectory<Read> {
+impl IntoIterator for XtcTrajectory<filemode::Read> {
     type Item = Result<Rc<Frame>>;
     type IntoIter = TrajectoryIterator<Self>;
 
@@ -23,7 +25,7 @@ impl IntoIterator for XtcTrajectory<Read> {
     }
 }
 
-impl IntoIterator for TrrTrajectory<Read> {
+impl IntoIterator for TrrTrajectory<filemode::Read> {
     type Item = Result<Rc<Frame>>;
     type IntoIter = TrajectoryIterator<Self>;
 
@@ -32,7 +34,7 @@ impl IntoIterator for TrrTrajectory<Read> {
     }
 }
 
-impl IntoIterator for XtcTrajectory<Append> {
+impl IntoIterator for XtcTrajectory<filemode::Append> {
     type Item = Result<Rc<Frame>>;
     type IntoIter = TrajectoryIterator<Self>;
 
@@ -41,7 +43,7 @@ impl IntoIterator for XtcTrajectory<Append> {
     }
 }
 
-impl IntoIterator for TrrTrajectory<Append> {
+impl IntoIterator for TrrTrajectory<filemode::Append> {
     type Item = Result<Rc<Frame>>;
     type IntoIter = TrajectoryIterator<Self>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ struct XdrFile<M: FileMode> {
     path: PathBuf,
 }
 
-impl<M: FileMode> XdrFile<M> {
+impl<M: FileMode + Default + Into<ErrorFileMode>> XdrFile<M> {
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref();
         unsafe {
@@ -226,7 +226,7 @@ pub struct XtcTrajectory<M: FileMode> {
     num_atoms: Lazy<Result<usize>>,
 }
 
-impl<M: FileMode> XtcTrajectory<M> {
+impl<M: FileMode + Default + Into<ErrorFileMode>> XtcTrajectory<M> {
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let xdr = XdrFile::open(path)?;
         Ok(Self {
@@ -395,7 +395,7 @@ pub struct TrrTrajectory<M: FileMode> {
     num_atoms: Lazy<Result<usize>>,
 }
 
-impl<M: FileMode> TrrTrajectory<M> {
+impl<M: FileMode + Default + Into<ErrorFileMode>> TrrTrajectory<M> {
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let xdr = XdrFile::open(path)?;
         Ok(Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,10 +64,9 @@ extern crate lazy_init;
 pub mod c_abi;
 mod errors;
 mod frame;
-mod iterator;
+pub mod iterator;
 pub use errors::*;
 pub use frame::Frame;
-pub use iterator::*;
 
 use c_abi::xdr_seek;
 use c_abi::xdrfile;
@@ -85,8 +84,8 @@ use std::marker::PhantomData;
 use std::os::raw::{c_float, c_int};
 use std::path::{Path, PathBuf};
 
-mod filemode;
-pub use filemode::*;
+pub mod filemode;
+use filemode::*;
 
 fn path_to_cstring(path: impl AsRef<Path>) -> Result<CString> {
     if let Some(s) = path.as_ref().to_str() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,7 +6,7 @@ mod integration {
 
     #[test]
     fn test_use_library() -> Result<()> {
-        let mut trj = XTCTrajectory::open_read("tests/1l2y.xtc")?;
+        let mut trj = XtcTrajectory::open_read("tests/1l2y.xtc")?;
         let num_atoms = trj.get_num_atoms()?;
         let mut frame = Frame::with_len(num_atoms);
 
@@ -18,7 +18,7 @@ mod integration {
 
     #[test]
     fn test_use_library_iterator() -> Result<()> {
-        let trj = XTCTrajectory::open_read("tests/1l2y.xtc")?;
+        let trj = XtcTrajectory::open_read("tests/1l2y.xtc")?;
         let frames: Result<Vec<Rc<Frame>>> = trj.into_iter().collect();
         for (idx, frame) in frames?.iter().enumerate() {
             assert_eq!(frame.step, idx + 1);


### PR DESCRIPTION
I refactored all the trajectory types to only implement the methods that were appropriate for the file mode it was opened in. This requires a lot of traits but means that mode checks happen at compile time rather than run time. Rust's type inference is really good, so all of the examples still work without modification :) Tests only needed changes to expected error types or construction of the private XdrFile struct, which doesn't have the open_read etc methods, which needed an explicit annotation. But neither of those things are things users would do, so this change should be a big plus for usability: No extra complications as long as you continue to use the open_read, open_append and open_write methods to construct trajectories, and statically checked file modes. Should even be faster and smaller in memory (by like a byte :P)

I also renamed XDRFile, XTCTrajectory and TRRTrajectory to XdrFile, XtcTrajectory and TrrTrajectory (which did require two changes to examples, just for clarity). This is in line with the [Rust naming conventions](https://github.com/rust-lang/rfcs/blob/master/text/0430-finalizing-naming-conventions.md): 

> In UpperCamelCase, acronyms count as one word: use Uuid rather than UUID.

This is an alternative to #11 
